### PR TITLE
Update azure-deploy.sh to be macOS compatible

### DIFF
--- a/azure-deploy.sh
+++ b/azure-deploy.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Load values from .env file or create it if it doesn't exists
 FILE=".env"
 if [[ -f $FILE ]]; then
-	echo "Loading from $FILE" 
-    eval $(egrep "^[^#;]" .env | xargs -d'\n' -n1 | sed 's/^/export /')
+	echo "Loading from $FILE"
+	eval $(egrep "^[^#;]" .env | tr '\n' '\0' | xargs -0 -n1 | sed 's/^/export /')
 else
 	cat << EOF > .env
 resourceGroup=""


### PR DESCRIPTION
MacOS's `xargs` doesn't have a `-d` option to specify the delimiter. I'm using the solution proposed in:
https://stackoverflow.com/questions/71409366/how-do-i-work-around-macos-x-not-having-xargs-d